### PR TITLE
🩹 Use Public ECR for Trivy artifacts

### DIFF
--- a/.github/workflows/scan.yml
+++ b/.github/workflows/scan.yml
@@ -31,6 +31,9 @@ jobs:
       - name: Scan
         id: scan
         uses: aquasecurity/trivy-action@6e7b7d1fd3e4fef0c5fa8cce1229c54b2c9bd0d8 # v0.24.0
+        env:
+          TRIVY_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-db:2
+          TRIVY_JAVA_DB_REPOSITORY: public.ecr.aws/aquasecurity/trivy-java-db:1
         with:
           image-ref: ghcr.io/${{ github.repository }}:${{ github.sha }}
           severity: HIGH,CRITICAL

--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,19 @@
-.PHONY: test build run
+.PHONY: build scan test run
 
 IMAGE_NAME ?= ghcr.io/ministryofjustice/analytical-platform-cloud-development-environment-base
 IMAGE_TAG  ?= local
+
+TRIVY_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-db:2
+TRIVY_JAVA_DB_REPOSITORY ?= public.ecr.aws/aquasecurity/trivy-java-db:1
 
 run: build
 	docker run --rm -it $(IMAGE_NAME):$(IMAGE_TAG)
 
 test: build
 	container-structure-test test --platform linux/amd64 --config test/container-structure-test.yml --image $(IMAGE_NAME):$(IMAGE_TAG)
+
+scan: build
+	trivy image --platform linux/amd64 --severity HIGH,CRITICAL $(IMAGE_NAME):$(IMAGE_TAG)
 
 build:
 	@ARCH=`uname --machine`; \


### PR DESCRIPTION
This pull request:

- Switches Trivy action to use ECR instead of GHCR (https://github.com/aquasecurity/trivy-action/issues/389)
- Adds scan option to Makefile

Signed-off-by: Jacob Woffenden <jacob.woffenden@digital.justice.gov.uk> 