### PR TITLE
🔧  Maintenance 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Health checks are implemented downstream of this image
 
-FROM public.ecr.aws/ubuntu/ubuntu@sha256:5b2fc4131b3c134a019c3ea815811de70e6ad9ee1626f59bf302558a95b436e5
+FROM public.ecr.aws/ubuntu/ubuntu@sha256:f3e3e5544acae3b8d20469e6aacd89576409f05070e76aeb999dddda98279112
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \
@@ -15,18 +15,18 @@ ENV CONTAINER_USER="analyticalplatform" \
     ANALYTICAL_PLATFORM_DIRECTORY="/opt/analytical-platform" \
     DEBIAN_FRONTEND="noninteractive" \
     PIP_BREAK_SYSTEM_PACKAGES="1" \
-    AWS_CLI_VERSION="2.18.0" \
+    AWS_CLI_VERSION="2.18.7" \
     AWS_SSO_CLI_VERSION="1.17.0" \
     MINICONDA_VERSION="24.7.1-0" \
     MINICONDA_SHA256="33442cd3813df33dcbb4a932b938ee95398be98344dff4c30f7e757cd2110e4f" \
     NODE_LTS_VERSION="20.18.0" \
-    CORRETTO_VERSION="1:21.0.4.7-1" \
+    CORRETTO_VERSION="1:21.0.5.11-1" \
     DOTNET_SDK_VERSION="8.0.110-0ubuntu1~24.04.1" \
     R_VERSION="4.4.1-3.2404.0" \
-    OLLAMA_VERSION="0.3.12" \
+    OLLAMA_VERSION="0.3.13" \
     KUBECTL_VERSION="1.29.9" \
-    HELM_VERSION="3.16.1" \
-    CLOUD_PLATFORM_CLI_VERSION="1.36.0" \
+    HELM_VERSION="3.16.2" \
+    CLOUD_PLATFORM_CLI_VERSION="1.36.1" \
     CUDA_VERSION="12.6.1" \
     NVIDIA_DISABLE_REQUIRE="true" \
     NVIDIA_CUDA_CUDART_VERSION="12.6.77-1" \

--- a/README.md
+++ b/README.md
@@ -136,12 +136,14 @@ apt-cache policy dotnet-sdk-8.0
 
 ### R
 
-The latest version of .NET SDK can be obtained by running:
+The latest version of R can be obtained by running:
 
 ```bash
 docker run -it --rm --platform linux/amd64 public.ecr.aws/ubuntu/ubuntu:24.04
 
 apt-get update --yes
+
+apt-get install --yes curl gpg
 
 curl --location --fail-with-body \
   "https://cloud.r-project.org/bin/linux/ubuntu/marutter_pubkey.asc" \
@@ -191,9 +193,9 @@ echo "deb [signed-by=/etc/apt/keyrings/nvidia.gpg] https://developer.download.nv
 
 apt-get update --yes
 
-apt-cache policy cuda-cudart-12-5
+apt-cache policy cuda-cudart-12-6
 
-apt-cache policy cuda-compat-12-5
+apt-cache policy cuda-compat-12-6
 ```
 
 ### Kubernetes CLI

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -42,7 +42,7 @@ commandTests:
   - name: "aws"
     command: "aws"
     args: ["--version"]
-    expectedOutput: ["aws-cli/2.18.0"]
+    expectedOutput: ["aws-cli/2.18.7"]
 
   - name: "aws-sso"
     command: "aws-sso"
@@ -72,7 +72,7 @@ commandTests:
   - name: "corretto"
     command: "java"
     args: ["--version"]
-    expectedOutput: ["openjdk 21.0.4"]
+    expectedOutput: ["openjdk 21.0.5"]
 
   - name: "dotnet"
     command: "dotnet"
@@ -87,7 +87,7 @@ commandTests:
   - name: "ollama"
     command: "ollama"
     args: ["--version"]
-    expectedOutput: ["0.3.12"]
+    expectedOutput: ["0.3.13"]
 
   - name: "kubectl"
     command: "kubectl"
@@ -97,12 +97,12 @@ commandTests:
   - name: "helm"
     command: "helm"
     args: ["version"]
-    expectedOutput: ["3.16.1"]
+    expectedOutput: ["3.16.2"]
 
   - name: "cloud-platform"
     command: "cloud-platform"
     args: ["--skip-version-check", "version"]
-    expectedOutput: ["1.36.0"]
+    expectedOutput: ["1.36.1"]
 
 fileExistenceTests:
   - name: "/opt/analytical-platform"


### PR DESCRIPTION
This PR is part of [this](https://github.com/ministryofjustice/analytical-platform/issues/5665) issue.

The PR updates the base development environment image with the latest versions of key tools and dependencies, including:

- Ubuntu 
- AWS CLI: 2.18.0 → 2.18.7
- Corretto: 21.0.4 → 21.0.5
- Helm: 3.16.1 → 3.16.2
- Ollama: 0.3.12 → 0.3.13
- Cloud Platform CLI 1.36.0 → 1.36.1