### PR TITLE
✨ Add `nbstripout`

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -163,7 +163,7 @@ EOF
 # nbstripout
 # Installs nbstripout (https://github.com/kynan/nbstripout)
 RUN <<EOF
-conda install -c conda-forge nbstripout==0.8.0 \
+pip install --no-cache nbstripout==0.8.0
 nbstripout --install --system
 EOF
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -160,6 +160,13 @@ chown --recursive "${CONTAINER_USER}":"${CONTAINER_GROUP}" /opt/conda
 rm --force miniconda.sh
 EOF
 
+# nbstripout
+# Installs nbstripout (https://github.com/kynan/nbstripout)
+RUN <<EOF
+conda install -c conda-forge nbstripout==0.8.0 \
+nbstripout --install --system
+EOF
+
 # Node.js LTS
 # Install Node.js LTS (https://nodejs.org/)
 RUN <<EOF

--- a/Dockerfile
+++ b/Dockerfile
@@ -163,7 +163,7 @@ EOF
 # nbstripout
 # Installs nbstripout (https://github.com/kynan/nbstripout)
 RUN <<EOF
-pip install --no-cache nbstripout==0.8.0
+pip install --no-cache-dir nbstripout==0.8.0
 nbstripout --install --system
 EOF
 

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -109,6 +109,11 @@ commandTests:
     args: ["--version"]
     expectedOutput: ["VIM - Vi IMproved 9.1"]
 
+  - name: "nbstripout"
+    command: "nbstripout"
+    args: ["--version"]
+    expectedOutput: ["0.8.0"]
+
 fileExistenceTests:
   - name: "/opt/analytical-platform"
     path: "/opt/analytical-platform"


### PR DESCRIPTION
Adding `nbstripout` via `pip` as per [this](https://github.com/ministryofjustice/analytical-platform/issues/5953) Issue. 

Using `pip` over `conda` as the latter caused the tests to fail. 

Adding in here instead of JupyterLab itself so it can be consumed in other tooling.