### PR TITLE
:art: Renovate: ignore specified dependencies + specify registry

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
       "matchStrings": [
         "#\\s*renovate:\\s*?(release=(?<release>.*?))?\\s*depName=(?<depName>.*?)?\\sENV .*?_VERSION=\"(?<currentValue>.*)\""
       ],
-      "registryUrlTemplate": "https://ports.ubuntu.com/ubuntu-ports?{{#if release }}release={{release}}{{else}}suite=stable{{/if}}&components=main,universe&binaryArch=amd64",
+      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu-ports?{{#if release }}release={{release}}{{else}}suite=stable{{/if}}&components=main,universe&binaryArch=amd64",
       "datasourceTemplate": "deb"
     }
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
       "matchStrings": [
         "#\\s*renovate:\\s*?(release=(?<release>.*?))?\\s*depName=(?<depName>.*?)?\\sENV .*?_VERSION=\"(?<currentValue>.*)\""
       ],
-      "registryUrlTemplate": "https://public.ecr.aws/ubuntu/ubuntu?{{#if release }}release={{release}}{{else}}suite=stable{{/if}}&components=main,universe&binaryArch=amd64",
+      "registryUrlTemplate": "https://ports.ubuntu.com/ubuntu-ports?{{#if release }}release={{release}}{{else}}suite=stable{{/if}}&components=main,universe&binaryArch=amd64",
       "datasourceTemplate": "deb"
     }
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
       "matchStrings": [
         "#\\s*renovate:\\s*?(release=(?<release>.*?))?\\s*depName=(?<depName>.*?)?\\sENV .*?_VERSION=\"(?<currentValue>.*)\""
       ],
-      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu-ports?{{#if release }}release={{release}}{{else}}suite=stable{{/if}}&components=main,universe&binaryArch=amd64",
+      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?{{#if release }}release={{release}}{{else}}suite=stable{{/if}}&components=main,universe&binaryArch=amd64",
       "datasourceTemplate": "deb"
     }
   ],

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,6 +15,10 @@
     {
       "matchManagers": ["custom.regex"],
       "enabled": true
+    },
+    {
+      "matchDepTypes": ["github-actions", "devcontainer"],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
This PR alters `registryUrlTemplate` to point to the correct mirror for the ubuntu packages. 

Ignore `github-actions`, `devcontainer`, `dockerfile` in `matchDepTypes`.