### PR TITLE
AP-6498 fix: hardcode ubuntu release 24.04 noble (as release is not specified)

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -5,9 +5,9 @@
       "customType": "regex",
       "fileMatch": ["^Dockerfile$"],
       "matchStrings": [
-        "#\\s*renovate:\\s*?(release=(?<release>.*?))?\\s*depName=(?<depName>.*?)?\\sENV .*?_VERSION=\"(?<currentValue>.*)\""
+        "#\\s*renovate:\\s*depName=(?<depName>.*?)?\\sENV .*?_VERSION=\"(?<currentValue>.*)\""
       ],
-      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu?{{#if release }}release={{release}}{{else}}suite=stable{{/if}}&components=main,universe&binaryArch=amd64",
+      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu/?release=noble-updates&components=main,universe&binaryArch=amd64",
       "datasourceTemplate": "deb"
     }
   ],


### PR DESCRIPTION
relates to ministryofjustice/analytical-platform#6498

fix: remove `release` from regex match for deb datasource
