### PR TITLE
AP-6498 feat: use release in registry url template

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -7,7 +7,7 @@
       "matchStrings": [
         "#\\s*renovate:\\s*?(release=(?<release>.*?))?\\s*depName=(?<depName>.*?)?\\sENV .*?_VERSION=\"(?<currentValue>.*)\""
       ],
-      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu/?release=noble-updates&components=main,universe&binaryArch=amd64",
+      "registryUrlTemplate": "https://archive.ubuntu.com/ubuntu/?release={{#if release }}{{release}}{{else}}noble-updates{{/if}}&components=main,universe&binaryArch=amd64",
       "datasourceTemplate": "deb"
     }
   ],


### PR DESCRIPTION
relates to ministryofjustice/analytical-platform#6498

fix: re-add `release` back into the `registryUrlTemplate`