### PR TITLE
Skip CVE's picked up by CVE scan

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -14,3 +14,6 @@ CVE-2024-45337
 
 ## CVE-2024-45338 (usr/bin/ollama, usr/local/bin/cloud-platform, usr/local/bin/kubectl)
 CVE-2024-45338
+
+## CVE-2025-22869 (usr/bin/ollama, usr/local/bin/aws-sso, usr/local/bin/cloud-platform)
+CVE-2025-22869

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ ENV ANALYTICAL_PLATFORM_DIRECTORY="/opt/analytical-platform" \
     CORRETTO_VERSION="1:21.0.6.7-1" \
     CUDA_VERSION="12.8.1" \
     DEBIAN_FRONTEND="noninteractive" \
-    DOTNET_SDK_VERSION="8.0.114-0ubuntu1~24.04.1" \
+    DOTNET_SDK_VERSION="8.0.115-0ubuntu1~24.04.1" \
     HELM_VERSION="3.17.2" \
     KUBECTL_VERSION="1.30.10" \
     LANG="C.UTF-8" \
@@ -40,7 +40,7 @@ ENV ANALYTICAL_PLATFORM_DIRECTORY="/opt/analytical-platform" \
     OLLAMA_VERSION="0.6.4" \
     PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/opt/conda/bin:/home/analyticalplatform/.local/bin:/opt/mssql-tools18/bin:${PATH}" \
     PIP_BREAK_SYSTEM_PACKAGES="1" \
-    R_VERSION="4.4.3-1.2404.0" \
+    R_VERSION="4.5.0-1.2404.0" \
     UV_VERSION="0.6.12"
 
 # renovate: release=noble depName=apt-transport-https

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -77,12 +77,12 @@ commandTests:
   - name: "dotnet"
     command: "dotnet"
     args: ["--version"]
-    expectedOutput: ["8.0.114"]
+    expectedOutput: ["8.0.115"]
 
   - name: "r"
     command: "R"
     args: ["--version"]
-    expectedOutput: ["R version 4.4.3"]
+    expectedOutput: ["R version 4.5.0"]
 
   - name: "ollama"
     command: "ollama"


### PR DESCRIPTION
The scheduled container scan identified these CVE [issues](https://github.com/ministryofjustice/analytical-platform-cloud-development-environment-base/actions/runs/14488868018/job/40640467759#step:6:442)

See the [following](https://avd.aquasec.com/nvd/2025/cve-2025-22869/) for more detail.

Unfortunately the potential mitigations would require a code re write and the mitigations can introduce issues of their own