### PR TITLE
Update required versions as result of CVE-2025-22868

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -24,3 +24,8 @@ CVE-2025-22869
 ## CVE-2025-22874 (usr/bin/ollama, usr/local/bin/aws-sso, usr/local/bin/helm, usr/bin/kubectl)
 CVE-2025-22874
 
+## CVE-2025-22868 (usr/local/bin/cloud-platform, usr/local/bin/kubectl)
+CVE-2025-22868
+
+## CVE-2022-40898 (Python (python-pkg))
+CVE-2022-40898

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,6 @@
 #checkov:skip=CKV_DOCKER_2: HEALTHCHECK not required - Health checks are implemented downstream of this image
 
-FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:adde43aa8a773e100cb2318bfb51d584bd25b914f99afdc710060cf5f5266ccd
+FROM public.ecr.aws/ubuntu/ubuntu:24.04@sha256:a0dc77bc556621fd5f59aa3a1ab15397e663d21df492eee218e9cbcedccd84a4
 
 LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.authors="Analytical Platform (analytical-platform@digital.justice.gov.uk)" \
@@ -9,18 +9,18 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/analytical-platform-cloud-development-environment-base"
 
 ENV ANALYTICAL_PLATFORM_DIRECTORY="/opt/analytical-platform" \
-    AWS_CLI_VERSION="2.27.47" \
+    AWS_CLI_VERSION="2.27.57" \
     AWS_SSO_CLI_VERSION="2.0.3" \
-    CLOUD_PLATFORM_CLI_VERSION="1.46.1" \
+    CLOUD_PLATFORM_CLI_VERSION="1.47.0" \
     CONTAINER_GID="1000" \
     CONTAINER_GROUP="analyticalplatform" \
     CONTAINER_UID="1000" \
     CONTAINER_USER="analyticalplatform" \
-    CORRETTO_VERSION="1:21.0.7.6-1" \
+    CORRETTO_VERSION="1:21.0.8.9-1" \
     CUDA_VERSION="12.9.1" \
     DEBIAN_FRONTEND="noninteractive" \
-    DOTNET_SDK_VERSION="8.0.117-0ubuntu1~24.04.1" \
-    HELM_VERSION="3.18.3" \
+    DOTNET_SDK_VERSION="8.0.118-0ubuntu1~24.04.1" \
+    HELM_VERSION="3.18.4" \
     KUBECTL_VERSION="1.31.10" \
     LANG="C.UTF-8" \
     LANGUAGE="C.UTF-8" \
@@ -28,20 +28,20 @@ ENV ANALYTICAL_PLATFORM_DIRECTORY="/opt/analytical-platform" \
     LD_LIBRARY_PATH="/usr/local/nvidia/lib:/usr/local/nvidia/lib64" \
     MICROSOFT_SQL_ODBC_VERSION="18.5.1.1-1" \
     MICROSOFT_SQL_TOOLS_VERSION="18.4.1.1-1" \
-    MINICONDA_SHA256="b99e5bcdf8cd2df9ffd11019eac8a20cf84598267941500935d62e14a0e2a6f6" \
-    MINICONDA_VERSION="25.5.1-0" \
+    MINICONDA_SHA256="e3228df32afc6d43cb190a416b91937cdcd1c6308d9fe652274539a07142966f" \
+    MINICONDA_VERSION="25.5.1-1" \
     NBSTRIPOUT_VERSION="0.8.1" \
-    NODE_LTS_VERSION="22.17.0" \
+    NODE_LTS_VERSION="22.17.1" \
     NVIDIA_CUDA_COMPAT_VERSION="575.57.08-0ubuntu1" \
     NVIDIA_CUDA_CUDART_VERSION="12.9.79-1" \
     NVIDIA_DISABLE_REQUIRE="true" \
     NVIDIA_DRIVER_CAPABILITIES="compute,utility" \
     NVIDIA_VISIBLE_DEVICES="all" \
-    OLLAMA_VERSION="0.9.4" \
+    OLLAMA_VERSION="0.9.6" \
     PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/opt/conda/bin:/home/analyticalplatform/.local/bin:/opt/mssql-tools18/bin:${PATH}" \
     PIP_BREAK_SYSTEM_PACKAGES="1" \
     R_VERSION="4.5.1-1.2404.0" \
-    UV_VERSION="0.7.18"
+    UV_VERSION="0.8.2"
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 
@@ -71,9 +71,9 @@ apt-get install --yes \
   "apt-transport-https=2.8.3" \
   "ca-certificates=20240203" \
   "curl=8.5.0-2ubuntu10.6" \
-  "git=1:2.43.0-1ubuntu7.2" \
+  "git=1:2.43.0-1ubuntu7.3" \
   "ffmpeg=7:6.1.1-3ubuntu5" \
-  "jq=1.7.1-3build1" \
+  "jq=1.7.1-3ubuntu0.24.04.1" \
   "mandoc=1.14.6-1" \
   "less=590-2ubuntu2.1" \
   "python3.12=3.12.3-1ubuntu0.7" \

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -127,7 +127,7 @@ commandTests:
   - name: "uvx"
     command: "uvx"
     args: ["--version"]
-    expectedOutput: ["uvx 0.7.18"]
+    expectedOutput: ["uvx 0.8.2"]
 
 fileExistenceTests:
   - name: "/opt/analytical-platform"

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -42,7 +42,7 @@ commandTests:
   - name: "aws"
     command: "aws"
     args: ["--version"]
-    expectedOutput: ["aws-cli/2.27.47"]
+    expectedOutput: ["aws-cli/2.27.57"]
 
   - name: "aws-sso"
     command: "aws-sso"
@@ -67,17 +67,17 @@ commandTests:
   - name: "node"
     command: "node"
     args: ["--version"]
-    expectedOutput: ["v22.17.0"]
+    expectedOutput: ["v22.17.1"]
 
   - name: "corretto"
     command: "java"
     args: ["--version"]
-    expectedOutput: ["openjdk 21.0.7"]
+    expectedOutput: ["openjdk 21.0.8"]
 
   - name: "dotnet"
     command: "dotnet"
     args: ["--version"]
-    expectedOutput: ["8.0.117"]
+    expectedOutput: ["8.0.118"]
 
   - name: "r"
     command: "R"
@@ -87,7 +87,7 @@ commandTests:
   - name: "ollama"
     command: "ollama"
     args: ["--version"]
-    expectedOutput: ["0.9.4"]
+    expectedOutput: ["0.9.6"]
 
   - name: "kubectl"
     command: "kubectl"
@@ -97,12 +97,12 @@ commandTests:
   - name: "helm"
     command: "helm"
     args: ["version"]
-    expectedOutput: ["3.18.3"]
+    expectedOutput: ["3.18.4"]
 
   - name: "cloud-platform"
     command: "cloud-platform"
     args: ["--skip-version-check", "version"]
-    expectedOutput: ["1.46.1"]
+    expectedOutput: ["1.47.0"]
 
   - name: "vim"
     command: "vim"
@@ -122,7 +122,7 @@ commandTests:
   - name: "uv"
     command: "uv"
     args: ["--version"]
-    expectedOutput: ["uv 0.7.18"]
+    expectedOutput: ["uv 0.8.2"]
 
   - name: "uvx"
     command: "uvx"


### PR DESCRIPTION
### Updates

| Variable                         | Old Version                          | New Version                          |
|----------------------------------|--------------------------------------|--------------------------------------|
| `AWS_CLI_VERSION`               | `2.27.47`                            | `2.27.57`                            |
| `CLOUD_PLATFORM_CLI_VERSION`    | `1.46.1`                             | `1.47.0`                             |
| `CORRETTO_VERSION`    | `1:21.0.7.6-1`                             | `1:21.0.8.9-1`                             |
| `DOTNET_SDK_VERSION`            | `8.0.117-0ubuntu1~24.04.1`           | `8.0.118-0ubuntu1~24.04.1`           |
| `HELM_VERSION`    | `3.18.3`                             | `3.18.4`                             |
| `MINICONDA_VERSION`    | `25.5.1-0`                             | `25.5.1-1`                             |
| `NODE_LTS_VERSION`    | `25.5.1-0`                             | `25.5.1-1`                             |
| `OLLAMA_VERSION`    | `0.9.4`                             | `0.9.6`                             |
| `UV_VERSION`                    | `0.7.18`                              | `0.8.2`                             |

Updating to latest versions failed to resolve [cve-2025-22868](https://avd.aquasec.com/nvd/cve-2025-22868 ) and introduced [cve-2022-40898](https://avd.aquasec.com/nvd/cve-2022-40898) I have added these to the trivy ignore.