### PR TITLE
Bump Development Environment Dependencies  as a result of  CVE alerts

### DIFF
--- a/.trivyignore
+++ b/.trivyignore
@@ -32,3 +32,6 @@ CVE-2022-40898
 
 ## CVE-2025-47907 (usr/bin/ollama, usr/local/bin/aws-sso, usr/local/bin/cloud-platform, usr/local/bin/helm, usr/local/bin/kubectl)
 CVE-2025-47907
+
+## CVE-2025-47906 (usr/bin/ollama, usr/local/bin/aws-sso, usr/local/bin/git-lfs, usr/local/bin/kubectl)
+CVE-2025-47906

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,8 +9,8 @@ LABEL org.opencontainers.image.vendor="Ministry of Justice" \
       org.opencontainers.image.url="https://github.com/ministryofjustice/analytical-platform-cloud-development-environment-base"
 
 ENV ANALYTICAL_PLATFORM_DIRECTORY="/opt/analytical-platform" \
-    AWS_CLI_VERSION="2.28.20" \
-    AWS_SSO_CLI_VERSION="2.0.3" \
+    AWS_CLI_VERSION="2.30.5" \
+    AWS_SSO_CLI_VERSION="2.1.0" \
     CLOUD_PLATFORM_CLI_VERSION="1.49.0" \
     CONTAINER_GID="1000" \
     CONTAINER_GROUP="analyticalplatform" \
@@ -21,7 +21,7 @@ ENV ANALYTICAL_PLATFORM_DIRECTORY="/opt/analytical-platform" \
     DEBIAN_FRONTEND="noninteractive" \
     DOTNET_SDK_VERSION="8.0.119-0ubuntu1~24.04.1" \
     GIT_LFS_VERSION="3.7.0" \
-    HELM_VERSION="3.18.6" \
+    HELM_VERSION="3.19.0" \
     KUBECTL_VERSION="1.33.4" \
     LANG="C.UTF-8" \
     LANGUAGE="C.UTF-8" \
@@ -33,16 +33,16 @@ ENV ANALYTICAL_PLATFORM_DIRECTORY="/opt/analytical-platform" \
     MINICONDA_VERSION="25.7.0-2" \
     NBSTRIPOUT_VERSION="0.8.1" \
     NODE_LTS_VERSION="22.19.0" \
-    NVIDIA_CUDA_COMPAT_VERSION="580.65.06-0ubuntu1" \
-    NVIDIA_CUDA_CUDART_VERSION="13.0.48-1" \
+    NVIDIA_CUDA_COMPAT_VERSION="580.82.07-0ubuntu1" \
+    NVIDIA_CUDA_CUDART_VERSION="13.0.88-1" \
     NVIDIA_DISABLE_REQUIRE="true" \
     NVIDIA_DRIVER_CAPABILITIES="compute,utility" \
     NVIDIA_VISIBLE_DEVICES="all" \
-    OLLAMA_VERSION="0.11.8" \
+    OLLAMA_VERSION="0.11.11" \
     PATH="/usr/local/nvidia/bin:/usr/local/cuda/bin:/opt/conda/bin:/home/analyticalplatform/.local/bin:/opt/mssql-tools18/bin:${PATH}" \
     PIP_BREAK_SYSTEM_PACKAGES="1" \
     R_VERSION="4.5.1-1.2404.0" \
-    UV_VERSION="0.8.14"
+    UV_VERSION="0.8.18"
 
 SHELL ["/bin/bash", "-e", "-u", "-o", "pipefail", "-c"]
 
@@ -79,7 +79,7 @@ apt-get install --yes \
   "less=590-2ubuntu2.1" \
   "python3.12=3.12.3-1ubuntu0.8" \
   "python3-pip=24.0+dfsg-1ubuntu1.2" \
-  "vim=2:9.1.0016-1ubuntu7.8" \
+  "vim=2:9.1.0016-1ubuntu7.9" \
   "unixodbc=2.3.12-1ubuntu0.24.04.1" \
   "unzip=6.0-28ubuntu4.1"
 

--- a/test/container-structure-test.yml
+++ b/test/container-structure-test.yml
@@ -42,12 +42,12 @@ commandTests:
   - name: "aws"
     command: "aws"
     args: ["--version"]
-    expectedOutput: ["aws-cli/2.28.20"]
+    expectedOutput: ["aws-cli/2.30.5"]
 
   - name: "aws-sso"
     command: "aws-sso"
     args: ["version"]
-    expectedOutput: ["AWS SSO CLI Version 2.0.3"]
+    expectedOutput: ["AWS SSO CLI Version 2.1.0"]
 
   - name: "conda"
     command: "conda"
@@ -87,7 +87,7 @@ commandTests:
   - name: "ollama"
     command: "ollama"
     args: ["--version"]
-    expectedOutput: ["0.11.8"]
+    expectedOutput: ["0.11.11"]
 
   - name: "kubectl"
     command: "kubectl"
@@ -97,7 +97,7 @@ commandTests:
   - name: "helm"
     command: "helm"
     args: ["version"]
-    expectedOutput: ["3.18.6"]
+    expectedOutput: ["3.19.0"]
 
   - name: "cloud-platform"
     command: "cloud-platform"
@@ -122,12 +122,12 @@ commandTests:
   - name: "uv"
     command: "uv"
     args: ["--version"]
-    expectedOutput: ["uv 0.8.14"]
+    expectedOutput: ["uv 0.8.18"]
 
   - name: "uvx"
     command: "uvx"
     args: ["--version"]
-    expectedOutput: ["uvx 0.8.14"]
+    expectedOutput: ["uvx 0.8.18"]
 
   - name: "git-lfs"
     command: "git-lfs"


### PR DESCRIPTION
This PR updates the versions of several key tools and packages used in the Analytical Platform container base image to ensure compatibility, security, and access to new features.

🔼 Version Upgrades

- AWS CLI: 2.28.20 ➝ 2.30.5

- AWS SSO CLI: 2.0.3 ➝ 2.1.0

- Helm: 3.18.6 ➝ 3.19.0

- NVIDIA CUDA Compatibility: 580.65.06-0ubuntu1 ➝ 580.82.07-0ubuntu1

- NVIDIA CUDA CUDART: 13.0.48-1 ➝ 13.0.88-1

- Ollama: 0.11.8 ➝ 0.11.11

- UV Package Manager: 0.8.14 ➝ 0.8.18

- Vim: 2:9.1.0016-1ubuntu7.8 ➝ 2:9.1.0016-1ubuntu7.9

Also includes a Trivy ignore for [CVE-2025-47906](https://avd.aquasec.com/nvd/cve-2025-47906)
