### PR TITLE
Add ignore for GHSA-hrxh-6v49-42gf

### DIFF
--- a/.grype.yml
+++ b/.grype.yml
@@ -279,3 +279,9 @@ ignore:
     reason: "dotnet SDK 8.0.129 bundles System.Security.Cryptography.Xml 8.0.4 in deps.json manifests; fix requires upstream Ubuntu dotnet package update. exp:2026-08-01"
   - vulnerability: GHSA-g8r8-53c2-pm3f
     reason: "dotnet SDK 8.0.129 bundles System.Security.Cryptography.Xml 8.0.4 in deps.json manifests; fix requires upstream Ubuntu dotnet package update. exp:2026-08-01"
+  # Alert fix 20260722
+  - vulnerability: GHSA-hrxh-6v49-42gf
+    package:
+      type: go-module
+      location: "/usr/bin/gh"
+    reason: "Detected in upstream precompiled gh binary (v2.96.0). Repo cannot patch transitive grpc module until cli/cli publishes a release rebuilt with grpc >=1.82.1. exp:2026-08-31"


### PR DESCRIPTION
This pull request adds a new vulnerability exception to the `.grype.yml` configuration. The exception documents a known vulnerability in a transitive dependency of the upstream precompiled `gh` binary, which cannot be patched until an upstream release is available.

Security and vulnerability management:

* [`.grype.yml`](diffhunk://#diff-5daeb107f00145e4181b32f14e4cfa38861fe6a7193bb7e71e967f9922e74567R282-R287): Added an ignore rule for vulnerability `GHSA-hrxh-6v49-42gf` found in the `gh` Go module binary, with an explanation and expiration date, to acknowledge and track the issue until it can be resolved upstream.